### PR TITLE
feat: support other package managers -- add tests for pnpm

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Use pnpm for version
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
       - run: npm ci
       - name: Build
         run: |
@@ -36,6 +40,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use Node.js 16
         uses: actions/setup-node@v4
+      - name: Use pnpm for version
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
       - name: Build
         run: |
           npm ci
@@ -45,7 +53,7 @@ jobs:
           npm install $(npx -y npm-min-peer lerna --major ${{ matrix.lerna-version }} --with-name)
           npm ls lerna
       - name: Integration test
-        run: npm exec jest --no-coverage integration
+        run: LERNA_VERSION=${{ matrix.lerna-version }} npm exec jest --no-coverage integration
 
   semantic-release:
     runs-on: ubuntu-latest
@@ -58,6 +66,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Use Node.js 16
         uses: actions/setup-node@v4
+      - name: Use pnpm for version
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
       - name: Build
         run: |
           npm ci

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -9,6 +9,11 @@ import { Package } from "@lerna/package";
 import { writeJsonFile } from "write-json-file";
 import semverParse from "semver/functions/parse.js";
 import getChangedPackages from "./get-changed-packages.js";
+import {
+	getLockFileFromPackageManager,
+	getPackageManagerFromLockFile,
+	getUpdateLockFileCommand,
+} from "./utils/package-manager-commands.js";
 
 /**
  * @param {string} path
@@ -83,35 +88,14 @@ async function updatePackage(npmrc, pkg, context, currentVersions) {
 async function updateLockfile(npmrc, pkg, context) {
 	const { env, stdout, stderr, logger } = context;
 
-	const packageManagerConfigs = [
-		[
-			"package-lock.json",
-			[
-				"npm",
-				"install",
-				"--package-lock-only",
-				"--ignore-scripts",
-				"--no-audit",
-				"--userconfig",
-				npmrc,
-			],
-		],
-		[
-			"pnpm-lock.yaml",
-			["pnpm", "install", "--lockfile-only", "--ignore-scripts", " --config", npmrc],
-		],
-		["yarn.lock", ["yarn", "install"]],
-	];
+	const packageManager = getPackageManagerFromLockFile(pkg.location);
+	const packageFile = getLockFileFromPackageManager(packageManager);
 
-	const packageManagerConfig = packageManagerConfigs.find(([file]) =>
-		existsSync(path.join(pkg.location, file)),
-	);
-
-	if (!packageManagerConfig) {
+	if (!existsSync(path.join(pkg.location, packageFile))) {
 		return;
 	}
 
-	const [packageFile, [command, ...options]] = packageManagerConfig;
+	const [command, ...options] = getUpdateLockFileCommand(packageManager, npmrc);
 
 	logger.log("Update %s file in %s", packageFile, pkg.location);
 

--- a/lib/utils/package-manager-commands.js
+++ b/lib/utils/package-manager-commands.js
@@ -1,0 +1,90 @@
+import path from "node:path";
+import { existsSync } from "node:fs";
+
+/**
+ * @typedef {'npm'|'pnpm'|'yarn'} PackageManager
+ */
+
+/**
+ * The list of configuration for package managers
+ * @type {[{lockFile: string, packageManager: PackageManager, updateLockFileCommand: string[]}]}
+ */
+const packageManagerConfigurations = [
+	{
+		packageManager: "npm",
+		lockFile: "package-lock.json",
+		updateLockFileCommand: [
+			"npm",
+			"install",
+			"--package-lock-only",
+			"--ignore-scripts",
+			"--no-audit",
+		],
+	},
+	{
+		packageManager: "pnpm",
+		lockFile: "pnpm-lock.yaml",
+		updateLockFileCommand: ["pnpm", "install", "--lockfile-only", "--ignore-scripts"],
+	},
+	{
+		packageManager: "yarn",
+		lockFile: "yarn.lock",
+		updateLockFileCommand: ["yarn", "install"],
+	},
+];
+
+/**
+ * Detect package manager from lockFile
+ * @param {string} location root of the project used to search for lockfile
+ * @returns {PackageManager}
+ */
+export function getPackageManagerFromLockFile(location) {
+	return (
+		packageManagerConfigurations.find(({ lockFile }) => existsSync(path.join(location, lockFile)))
+			?.packageManager ?? "npm"
+	);
+}
+
+/**
+ * define lockfile from package manager
+ * @param {PackageManager} packageManager
+ * @returns {string}
+ */
+export function getLockFileFromPackageManager(packageManager) {
+	return packageManagerConfiguration(packageManager).lockFile;
+}
+
+/**
+ * @param {PackageManager} pm the package manager
+ * @returns {{lockFile: string, packageManager: ("npm"|"pnpm"|"yarn"), updateLockFileCommand: string[]}} the associated configuration
+ */
+function packageManagerConfiguration(pm) {
+	return packageManagerConfigurations.find(({ packageManager }) => packageManager === pm);
+}
+
+/**
+ * Add dynamic configuration to a command
+ * @param {(any) => string[]} commandSelector
+ * @param {PackageManager} packageManager
+ * @param {string} npmrc
+ * @returns {string[]}
+ */
+function findAndPrepareCommand(commandSelector, packageManager, npmrc) {
+	const command = commandSelector(packageManagerConfiguration(packageManager));
+	const extension = packageManager === "npm" ? ["--userconfig", npmrc] : [];
+	return [...command, ...extension];
+}
+
+/**
+ * Get the update lockFile command
+ * @param {PackageManager} packageManager
+ * @param {string} npmrc
+ * @returns {string[]}
+ */
+export function getUpdateLockFileCommand(packageManager, npmrc) {
+	return findAndPrepareCommand(
+		(configuration) => configuration.updateLockFileCommand,
+		packageManager,
+		npmrc,
+	);
+}


### PR DESCRIPTION
I am adding some tests on `pnpm`.   
And also a refactoring to centralise some of the commands.

But I am not sure they will run with Github Actions.